### PR TITLE
feat(client): adding tenantId as custom prop

### DIFF
--- a/src/FeatureToggleInstanceFactory.ts
+++ b/src/FeatureToggleInstanceFactory.ts
@@ -7,8 +7,9 @@ const getApplicationData = (p: any) : LDUser =>
   p.hasCluster
     ? {
         custom: {
+          cluster: p.cluster,
           group: 'bot',
-          tenantId: p.tenantId
+          tenantId: p.tenantId,
         },
         email: `${p.shortName}@msging.net`,
         key: p.shortName,


### PR DESCRIPTION
- Adding the application/bot tenantId as a custom prop from LDUser. Only done for paid bots (hasCluster == true), as free bots are grouped under a single LDUser.
- Refactoring and renaming some methods.